### PR TITLE
feat: add user authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ See [docs/PROMISES_TO_FEATURES.md](docs/PROMISES_TO_FEATURES.md) for the mapping
 - Node.js 20
 - pnpm
 - (for live scanning) system tools: `nmap`, `sqlmap`, `whois`, `curl`
+  - install on Debian/Ubuntu via `apt-get install nmap sqlmap`
+  - set `USE_MOCKS=false` to enable live scans
 
 ### Installation
 ```sh

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server';
+import { authenticate } from '@/lib/users';
+import { signToken } from '@/lib/auth';
+import { rateLimit } from '@/lib/rate-limit';
+
+export async function POST(request: Request) {
+  const ip = request.headers.get('x-forwarded-for') || 'unknown';
+  if (!rateLimit(ip)) {
+    return NextResponse.json({ code: 'RATE_LIMIT', message: 'Too many requests' }, { status: 429 });
+  }
+  try {
+    const body = await request.json();
+    const { email, password } = body as { email?: string; password?: string };
+    if (!email || !password) {
+      return NextResponse.json({ code: 'BAD_REQUEST', message: 'Email and password required' }, { status: 400 });
+    }
+    const user = authenticate(email, password);
+    if (!user) {
+      return NextResponse.json({ code: 'UNAUTHORIZED', message: 'Invalid credentials' }, { status: 401 });
+    }
+    const token = signToken({ sub: user.id, email: user.email, exp: Math.floor(Date.now() / 1000) + 60 * 60 });
+    return NextResponse.json({ token, user }, { headers: { 'Access-Control-Allow-Origin': '*' } });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Invalid request';
+    return NextResponse.json({ code: 'BAD_REQUEST', message }, { status: 400 });
+  }
+}
+
+export function OPTIONS() {
+  return NextResponse.json(
+    {},
+    {
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'POST,OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type',
+      },
+    }
+  );
+}

--- a/app/api/users/[id]/route.ts
+++ b/app/api/users/[id]/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from 'next/server';
+import { getUser, updateUser, deleteUser, userSchema } from '@/lib/users';
+import { rateLimit } from '@/lib/rate-limit';
+
+export async function GET(request: Request, { params }: { params: { id: string } }) {
+  const ip = request.headers.get('x-forwarded-for') || 'unknown';
+  if (!rateLimit(ip)) {
+    return NextResponse.json({ code: 'RATE_LIMIT', message: 'Too many requests' }, { status: 429 });
+  }
+  const user = getUser(params.id);
+  if (!user) {
+    return NextResponse.json({ code: 'NOT_FOUND', message: 'User not found' }, { status: 404 });
+  }
+  return NextResponse.json(user, { headers: { 'Access-Control-Allow-Origin': '*' } });
+}
+
+export async function PUT(request: Request, { params }: { params: { id: string } }) {
+  const ip = request.headers.get('x-forwarded-for') || 'unknown';
+  if (!rateLimit(ip)) {
+    return NextResponse.json({ code: 'RATE_LIMIT', message: 'Too many requests' }, { status: 429 });
+  }
+  try {
+    const body = await request.json();
+    const data = userSchema.parse(body);
+    const user = updateUser(params.id, data);
+    if (!user) {
+      return NextResponse.json({ code: 'NOT_FOUND', message: 'User not found' }, { status: 404 });
+    }
+    return NextResponse.json(user, { headers: { 'Access-Control-Allow-Origin': '*' } });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Invalid request';
+    return NextResponse.json({ code: 'BAD_REQUEST', message }, { status: 400 });
+  }
+}
+
+export async function DELETE(request: Request, { params }: { params: { id: string } }) {
+  const ip = request.headers.get('x-forwarded-for') || 'unknown';
+  if (!rateLimit(ip)) {
+    return NextResponse.json({ code: 'RATE_LIMIT', message: 'Too many requests' }, { status: 429 });
+  }
+  const removed = deleteUser(params.id);
+  if (!removed) {
+    return NextResponse.json({ code: 'NOT_FOUND', message: 'User not found' }, { status: 404 });
+  }
+  return NextResponse.json({ success: true }, { headers: { 'Access-Control-Allow-Origin': '*' } });
+}
+
+export function OPTIONS() {
+  return NextResponse.json({}, { headers: { 'Access-Control-Allow-Origin': '*', 'Access-Control-Allow-Methods': 'GET,PUT,DELETE,OPTIONS', 'Access-Control-Allow-Headers': 'Content-Type' } });
+}

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+import { listUsers, createUser, userSchema } from '@/lib/users';
+import { rateLimit } from '@/lib/rate-limit';
+
+export async function GET(request: Request) {
+  const ip = request.headers.get('x-forwarded-for') || 'unknown';
+  if (!rateLimit(ip)) {
+    return NextResponse.json({ code: 'RATE_LIMIT', message: 'Too many requests' }, { status: 429 });
+  }
+  return NextResponse.json(listUsers(), { headers: { 'Access-Control-Allow-Origin': '*' } });
+}
+
+export async function POST(request: Request) {
+  const ip = request.headers.get('x-forwarded-for') || 'unknown';
+  if (!rateLimit(ip)) {
+    return NextResponse.json({ code: 'RATE_LIMIT', message: 'Too many requests' }, { status: 429 });
+  }
+  try {
+    const body = await request.json();
+    const data = userSchema.parse(body);
+    const user = createUser(data);
+    return NextResponse.json(user, { headers: { 'Access-Control-Allow-Origin': '*' }, status: 201 });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Invalid request';
+    return NextResponse.json({ code: 'BAD_REQUEST', message }, { status: 400 });
+  }
+}
+
+export function OPTIONS() {
+  return NextResponse.json({}, { headers: { 'Access-Control-Allow-Origin': '*', 'Access-Control-Allow-Methods': 'GET,POST,OPTIONS', 'Access-Control-Allow-Headers': 'Content-Type' } });
+}

--- a/lib/adapters/live.ts
+++ b/lib/adapters/live.ts
@@ -83,13 +83,16 @@ export class LiveProvider implements Provider {
   ): string {
     switch (tool) {
       case 'nmap':
-        return `nmap ${target}`;
+        // -Pn treats targets as online even if they ignore ping probes
+        return `nmap -Pn ${target}`;
       case 'sqlmap':
-        return `sqlmap -u ${target} --batch`;
+        // minimal flags for non-interactive runs
+        return `sqlmap -u ${target} --batch --crawl=0 --level=1 --risk=1`;
       case 'osint':
         return `whois ${target}`;
       case 'web':
-        return `curl -I ${target}`;
+        // follow redirects and fetch headers
+        return `curl -L -I ${target}`;
       default:
         return `echo unknown tool`;
     }

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,33 @@
+import { createHmac } from 'crypto';
+
+const SECRET = process.env.JWT_SECRET || 'dev-secret';
+
+function base64url(input: Buffer | string) {
+  return Buffer.from(input).toString('base64url');
+}
+
+export interface TokenPayload {
+  sub: string;
+  email: string;
+  exp: number;
+}
+
+export function signToken(payload: TokenPayload): string {
+  const header = { alg: 'HS256', typ: 'JWT' };
+  const encodedHeader = base64url(JSON.stringify(header));
+  const encodedPayload = base64url(JSON.stringify(payload));
+  const data = `${encodedHeader}.${encodedPayload}`;
+  const signature = createHmac('sha256', SECRET).update(data).digest('base64url');
+  return `${data}.${signature}`;
+}
+
+export function verifyToken(token: string): TokenPayload | null {
+  const [header, payload, signature] = token.split('.');
+  if (!header || !payload || !signature) return null;
+  const data = `${header}.${payload}`;
+  const expected = createHmac('sha256', SECRET).update(data).digest('base64url');
+  if (signature !== expected) return null;
+  const parsed = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8')) as TokenPayload;
+  if (parsed.exp < Math.floor(Date.now() / 1000)) return null;
+  return parsed;
+}

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -1,0 +1,79 @@
+import { randomUUID, randomBytes, pbkdf2Sync, timingSafeEqual } from 'crypto';
+import { z } from 'zod';
+
+export interface PublicUser {
+  id: string;
+  name: string;
+  email: string;
+}
+
+interface StoredUser extends PublicUser {
+  passwordHash: string;
+  salt: string;
+}
+
+const users: StoredUser[] = [];
+
+export const userSchema = z.object({
+  name: z.string().min(1),
+  email: z.string().email(),
+  password: z.string().min(6),
+});
+
+function hashPassword(password: string, salt: string) {
+  return pbkdf2Sync(password, salt, 10000, 64, 'sha512').toString('hex');
+}
+
+function sanitize(user: StoredUser): PublicUser {
+  const { id, name, email } = user;
+  return { id, name, email };
+}
+
+export function listUsers(): PublicUser[] {
+  return users.map(sanitize);
+}
+
+export function createUser(data: z.infer<typeof userSchema>): PublicUser {
+  const salt = randomBytes(16).toString('hex');
+  const user: StoredUser = {
+    id: randomUUID(),
+    name: data.name,
+    email: data.email,
+    salt,
+    passwordHash: hashPassword(data.password, salt),
+  };
+  users.push(user);
+  return sanitize(user);
+}
+
+export function getUser(id: string): PublicUser | undefined {
+  const user = users.find((u) => u.id === id);
+  return user ? sanitize(user) : undefined;
+}
+
+export function updateUser(id: string, data: z.infer<typeof userSchema>): PublicUser | undefined {
+  const user = users.find((u) => u.id === id);
+  if (!user) return undefined;
+  user.name = data.name;
+  user.email = data.email;
+  user.salt = randomBytes(16).toString('hex');
+  user.passwordHash = hashPassword(data.password, user.salt);
+  return sanitize(user);
+}
+
+export function deleteUser(id: string): boolean {
+  const index = users.findIndex((u) => u.id === id);
+  if (index === -1) return false;
+  users.splice(index, 1);
+  return true;
+}
+
+export function authenticate(email: string, password: string): PublicUser | null {
+  const user = users.find((u) => u.email === email);
+  if (!user) return null;
+  const hash = hashPassword(password, user.salt);
+  if (!timingSafeEqual(Buffer.from(hash, 'hex'), Buffer.from(user.passwordHash, 'hex'))) {
+    return null;
+  }
+  return sanitize(user);
+}

--- a/tests/integration/api.users.test.ts
+++ b/tests/integration/api.users.test.ts
@@ -1,0 +1,42 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import { POST as createUser } from '@/app/api/users/route';
+import { POST as login } from '@/app/api/auth/login/route';
+
+describe('users API', () => {
+  it('registers and logs in user', async () => {
+    const res = await createUser(
+      new Request('http://localhost/api/users', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ name: 'Alice', email: 'alice@example.com', password: 'secret123' }),
+      })
+    );
+    expect(res.status).toBe(201);
+    const created = await res.json();
+    expect(created.email).toBe('alice@example.com');
+
+    const loginRes = await login(
+      new Request('http://localhost/api/auth/login', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ email: 'alice@example.com', password: 'secret123' }),
+      })
+    );
+    expect(loginRes.ok).toBe(true);
+    const data = await loginRes.json();
+    expect(data.user.email).toBe('alice@example.com');
+    expect(typeof data.token).toBe('string');
+  });
+
+  it('rejects invalid login', async () => {
+    const res = await login(
+      new Request('http://localhost/api/auth/login', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ email: 'wrong@example.com', password: 'nope' }),
+      })
+    );
+    expect(res.status).toBe(401);
+  });
+});

--- a/tests/integration/liveProvider.test.ts
+++ b/tests/integration/liveProvider.test.ts
@@ -12,4 +12,23 @@ describe('LiveProvider', () => {
     const summary = await provider.getSummary();
     expect(summary.total).toBe(1);
   }, 20000);
+
+  it('executes nmap scan', async () => {
+    const provider = new LiveProvider();
+    const { scanId } = await provider.runTool({ tool: 'nmap', target: 'example.com' });
+    await new Promise((r) => setTimeout(r, 2000));
+    const result = await provider.getScan(scanId);
+    expect(result.output.stdout).toContain('Nmap');
+    expect(result.status).toBe('completed');
+  }, 20000);
+
+  it('executes sqlmap scan', async () => {
+    const provider = new LiveProvider();
+    const target = 'http://testphp.vulnweb.com/listproducts.php?cat=1';
+    const { scanId } = await provider.runTool({ tool: 'sqlmap', target });
+    await new Promise((r) => setTimeout(r, 15000));
+    const result = await provider.getScan(scanId);
+    expect(result.output.stdout).toContain('sqlmap');
+    expect(result.status).toBe('completed');
+  }, 120000);
 });


### PR DESCRIPTION
## Summary
- extend user library with password hashing and authentication
- implement JWT auth helpers and login API route
- add integration tests for user registration and login
- expand live scan provider with nmap/sqlmap/web command support and tests
- document system tool requirements for running real scans

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68afa858dc64832592ebdb9a37195097