### PR TITLE
Add Aho-Corasick-based anomaly detection

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ curl_cffi
 cloudscraper
 PyQt6
 PyQt6-sip
+pyahocorasick

--- a/sqli_hunter/attack_signatures.json
+++ b/sqli_hunter/attack_signatures.json
@@ -1,0 +1,9 @@
+{
+  "signatures": [
+    {"pattern": "union select", "weight": 0.15},
+    {"pattern": "information_schema", "weight": 0.15},
+    {"pattern": "syntax error", "weight": 0.2},
+    {"pattern": "warning: mysql", "weight": 0.25},
+    {"pattern": "unclosed quotation mark", "weight": 0.25}
+  ]
+}


### PR DESCRIPTION
## Summary
- Load attack signatures from new JSON file and build an Aho–Corasick automaton on scanner start
- Use automaton matches with weights to influence anomaly scoring
- Include pyahocorasick dependency and attack signature dataset

## Testing
- `python -m py_compile sqli_hunter/scanner.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b780683250832594a6de5c607c9bf7